### PR TITLE
DCOPS-36934: Remove public_facing mis-tag from catalog.yaml

### DIFF
--- a/.customink/catalog.yaml
+++ b/.customink/catalog.yaml
@@ -22,6 +22,6 @@ deployment_type: # multiple choice
 tier: tier_na # this repo does not have a tier. typically libraries
 
 properties:
-  public_facing: true
+  public_facing: false
   pci: false
   pii: false


### PR DESCRIPTION
## JIRA Ticket

[DCOPS-36934](https://customink.atlassian.net/browse/DCOPS-36934) — part of [DCOPS-36457](https://customink.atlassian.net/browse/DCOPS-36457) (Securing external apps, services, and endpoints)

## What

Sets `properties.public_facing` from `true` to `false` in `.customink/catalog.yaml`.

## Why

`sass_paths` is catalogued as `purpose: library` / `deployment_type: package`. It ships no deployable service, so it has no endpoint of any kind and `public_facing: true` was never accurate.

The flag matters because the Q3 security initiative uses `public_facing` to build the inventory of internet-reachable apps. A library carrying the flag lands on that inventory and consumes audit time that belongs to real endpoints — this repo was flagged in DCOPS-36934 as "tagged public_facing but is a JS library."

## Note for funnelcake

Opened by WebOps rather than by the owning team because it came out of the DCOPS-36457 audit sweep. `catalog.yaml` records `owner: funnelcake`, so this is your repo — happy to close it if you'd rather make the change yourselves. No behaviour changes; catalog metadata only.

A sibling PR does the same for `sizing_lineups`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DCOPS-36934]: https://customink.atlassian.net/browse/DCOPS-36934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCOPS-36457]: https://customink.atlassian.net/browse/DCOPS-36457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ